### PR TITLE
Dev kogepanh

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <title>NISLAB OpenLAB</title>
     <meta name="author" content="Network Information Systems Lab.">
     <meta name="description" content="2021年2月15日(月)にオープンラボを開催します。オンライン/オフラインのハイブリッド開催しますので、ぜひご参加ください。">
-    <meta property="og:url" content="<%= BASE_URL %>">
+    <meta property="og:url" content="https://openlab.nislab.info/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="NISLAB オープンラボ特設サイト">
     <meta property="og:description" content="2021年2月15日(月)にオープンラボを開催します。オンライン/オフラインのハイブリッド開催しますので、ぜひご参加ください。">

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="NISLAB オープンラボ特設サイト">
     <meta property="og:description" content="2021年2月15日(月)にオープンラボを開催します。オンライン/オフラインのハイブリッド開催しますので、ぜひご参加ください。">
-    <meta property="og:image" content="<%= BASE_URL %>summary-card.png">
+    <meta property="og:image" content="https://openlab.nislab.info/summary-card.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@nislab_sato">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">


### PR DESCRIPTION
meta の og:url や og:image では `<%= BASE_URL =>` は使えないため、絶対パスを指定